### PR TITLE
Lower case href to assets folder

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
   <link href="https://fonts.googleapis.com/css?family=Poppins&display=swap" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="./Assets/style.css" />
+  <link rel="stylesheet" type="text/css" href="./assets/style.css" />
 
   <title>Megan John</title>
 


### PR DESCRIPTION
Assets folder is lowercased by github pages. href was referring to upper cased directory which returned 404.